### PR TITLE
Update rubocop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+**/.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,85 @@
+PATH
+  remote: .
+  specs:
+    rubocop-mutiny (1.0.0)
+      rubocop (~> 1.18)
+      rubocop-rails (~> 2.11)
+      rubocop-rspec (~> 2.4)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    activesupport (6.1.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
+    ast (2.4.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    diff-lcs (1.4.4)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    minitest (5.14.4)
+    parallel (1.20.1)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rack (2.2.3)
+    rainbow (3.0.0)
+    rake (10.5.0)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.18.4)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.8.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.8.0)
+      parser (>= 3.0.1.1)
+    rubocop-rails (2.11.3)
+      activesupport (>= 4.2.0)
+      rack (>= 1.1)
+      rubocop (>= 1.7.0, < 2.0)
+    rubocop-rspec (2.4.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.11.0)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.0.0)
+    zeitwerk (2.4.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 2.1)
+  pry
+  rake (~> 10.0)
+  rspec (~> 3.7)
+  rubocop-mutiny!
+
+BUNDLED WITH
+   2.1.4

--- a/config/default.yml
+++ b/config/default.yml
@@ -1,11 +1,13 @@
+require:
+  - rubocop-rails
+  - rubocop-rspec
+
 #
 # Global config
 #
 AllCops:
   TargetRubyVersion: 2.5
   DisplayCopNames: true
-require:
-  - rubocop-rspec
 
 Indentation:
   IgnoredMethods:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -18,6 +18,10 @@ Layout/FirstMethodParameterLineBreak:
 Layout/MultilineAssignmentLayout:
   Enabled: true
   EnforcedStyle: same_line
+Layout/MultilineHashKeyLineBreaks:
+  Enabled: true
+Layout/MultilineMethodArgumentLineBreaks:
+  Enabled: true
 
 # Updated Settings
 Layout/AlignParameters:

--- a/config/enabled.yml
+++ b/config/enabled.yml
@@ -107,8 +107,6 @@ Style/DoubleNegation:
   Enabled: true
 Style/MultilineBlockChain:
   Enabled: true
-Style/MethodCalledOnDoEndBlock:
-  Enabled: true
 
 Style/FirstArrayElementLineBreak:
   Enabled: true
@@ -146,7 +144,7 @@ Style/SpaceAroundEqualsInParameterDefault:
 #
 # 120 is a reasonable max line length
 #
-Metrics/LineLength:
+Layout/LineLength:
   Enabled: true
   Max: 120
 

--- a/lib/rubocop/cop/layout/mixin/multiline_layout.rb
+++ b/lib/rubocop/cop/layout/mixin/multiline_layout.rb
@@ -10,7 +10,7 @@ module RuboCop
         private
 
         def check_method_line_break(node, children)
-          return if ignored_method?(node.method_name)
+          return if node.respond_to?(:method_name) && ignored_method?(node.method_name)
           return if children.empty?
 
           check_children_line_break(node, children)

--- a/lib/rubocop/cop/layout/multiline_method_call_layout.rb
+++ b/lib/rubocop/cop/layout/multiline_method_call_layout.rb
@@ -37,6 +37,7 @@ module RuboCop
           # when determining where line breaks should appear.
           if (last_arg = args.last)
             if last_arg.hash_type? && !last_arg.braces?
+              args = args.dup
               args = args.concat(args.pop.children)
             end
           end

--- a/lib/rubocop/mutiny/version.rb
+++ b/lib/rubocop/mutiny/version.rb
@@ -1,5 +1,5 @@
 module Rubocop
   module Mutiny
-    VERSION = "1.0.0"
+    VERSION = "2.0.0"
   end
 end

--- a/rubocop-mutiny.gemspec
+++ b/rubocop-mutiny.gemspec
@@ -1,39 +1,40 @@
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "rubocop/mutiny/version"
+require 'rubocop/mutiny/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "rubocop-mutiny"
+  spec.name          = 'rubocop-mutiny'
   spec.version       = Rubocop::Mutiny::VERSION
-  spec.authors       = ["Nikhil Mathew"]
-  spec.email         = ["nikhilmat@gmail.com"]
+  spec.authors       = ['Nikhil Mathew']
+  spec.email         = ['nikhilmat@gmail.com']
 
   spec.summary       = 'Rubocop configuration for Mutiny Ruby applications.'
-  spec.homepage      = "https://github.com/nikhilmat/rubocop-mutiny"
-  spec.license       = "MIT"
+  spec.homepage      = 'https://github.com/nikhilmat/rubocop-mutiny'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '~> 0.52.0'
-  spec.add_dependency 'rubocop-rspec', '~> 1.21'
+  spec.add_runtime_dependency 'rubocop', '~> 1.18'
+  spec.add_dependency 'rubocop-rails', '~> 2.11'
+  spec.add_dependency 'rubocop-rspec', '~> 2.4'
 
-  spec.add_development_dependency "bundler", "~> 1.15"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "rspec", "~> 3.7"
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rspec', '~> 3.7'
 end

--- a/rubocop-mutiny.gemspec
+++ b/rubocop-mutiny.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '~> 1.18'
-  spec.add_dependency 'rubocop-rails', '~> 2.11'
-  spec.add_dependency 'rubocop-rspec', '~> 2.4'
+  spec.add_runtime_dependency 'rubocop', '~> 1.36'
+  spec.add_dependency 'rubocop-rails', '~> 2.16.1'
+  spec.add_dependency 'rubocop-rspec', '~> 2.13.2'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 10.0'


### PR DESCRIPTION
Updates rubocop version so that we can have some of the updated Cops and options.

Large upgrade of rubocop from `0.52` to `1.18`.

Was tired of running into this issue: https://github.com/rubocop/rubocop/issues/3344

And wanted access to the 'AllowInReturns' option for 'Style/DoubleNegation', which is now default

Had to make some minor changes to some of the custom cops with the updated versions of the AST.